### PR TITLE
ci(doc): pin ubuntu 22.04

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -52,7 +52,7 @@ jobs:
     name: Deploy docs
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       UV_HTTP_TIMEOUT: 900 # max 15min to install deps
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the documentation deployment workflow to run on Ubuntu 22.04.
	- Improved Python setup process for documentation deployment.
	- Added a new command for deploying documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->